### PR TITLE
Adapt plugin to GitBook 3

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,0 +1,6 @@
+{% extends template.self %}
+
+{% block head %}
+    {{ super() }}
+    <link rel="canonical" href="{{ config.pluginsConfig['canonical-link'].canonicalURL }}">
+{% endblock %}

--- a/index.js
+++ b/index.js
@@ -1,9 +1,0 @@
-// LICENSE : MIT
-"use strict";
-module.exports = {
-    website: {
-        html: {
-            "head:end": '<link rel="canonical" href="' + this.options.canonicalURL + '">',
-        }
-    }
-};

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "engines": {
     "gitbook": "*"
   },
-  "main": "index.js",
   "files": [
     "index.js"
   ],

--- a/package.json
+++ b/package.json
@@ -28,5 +28,14 @@
     "gitbook",
     "gitbook-plugin",
     "header"
-  ]
+  ],
+  "gitbook": {
+    "properties": {
+      "canonicalURL": {
+        "type": "string",
+        "description": "Canonical URL",
+        "required": true
+      }
+    }
+  }
 }


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
In this version, the hooks used for this plugin will not be supported, since we are relying a lot more on the templating system to extend the books HTML.

The proposed PR has been tested with the new version.
Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it :)

For compatibility reasons, your new version's `package.json` must reference the new gitbook engine:

``` JSON
"engines": {
    "gitbook": ">=3.0.0-pre.0"
}
```

Kind regards,
Johan
