### PR TITLE
Replace custom index file by reading from config

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -2,5 +2,5 @@
 
 {% block head %}
     {{ super() }}
-    <link rel="canonical" href="{{ config.pluginsConfig['canonical-link'].baseURL }}/{{ file.path | replace('index.html.md','') | replace('README.md','') | replace('readme.md','') | replace('.md','.html') | replace('.adoc','.html')}}">
+    <link rel="canonical" href="{{ config.pluginsConfig['canonical-link'].baseURL }}/{{ file.path | replace(config.structure['readme'],'') | replace('index.html.md','') | replace('README.md','') | replace('readme.md','') | replace('.md','.html') | replace('.adoc','.html')}}">
 {% endblock %}


### PR DESCRIPTION
We use a custom index file. This reads the custom index markdown file and replaces for the root URL of the site.